### PR TITLE
Add dokka to generate documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:2.3.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.14"
     }
 }
 

--- a/gradle/gradle-mvn-publish.gradle
+++ b/gradle/gradle-mvn-publish.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'org.jetbrains.dokka-android'
 
 version = VERSION_NAME
 group = GROUP
@@ -47,4 +48,8 @@ uploadArchives {
         sign configurations.archives
     }
 
+    dokka {
+        outputFormat 'javadoc'
+        outputDirectory "$buildDir/javadoc"
+    }
 }


### PR DESCRIPTION
Closes #7 by adding [dokka](https://github.com/Kotlin/dokka) gradle plugin to generate documentation.

Plugin adds `dokka` task, that can be run executing `./gradlew dokka` command or from IDE.

Examples:
![image](https://user-images.githubusercontent.com/10222326/31946693-2ced27a0-b8db-11e7-9123-9936e1fe34d1.png)
![image](https://user-images.githubusercontent.com/10222326/31946712-34345f10-b8db-11e7-935b-9a68ab0b19de.png)
