### PR TITLE
Add simple backtrace catalog info config

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: dependencies-overview
+  description: |
+    Gradle plugin which gathers project dependencies and exports them in Markdown/JSON format.
+  links:
+    - title: Website
+      url: https://github.com/vgaidarji/dependencies-overview
+    - title: Documentation
+      url: https://github.com/vgaidarji/dependencies-overview/blob/master/README.md
+  annotations:
+    github.com/project-slug: vgaidarji/dependencies-overview
+spec:
+  type: library
+  owner: vgaidarji
+  lifecycle: experimental
+  


### PR DESCRIPTION
### What has been done
- Added backtrace.io catalog info descriptor file. This is to allow for repository import into backtrace.io dev portal.

https://backstage.io/docs/features/software-catalog/descriptor-format