### PR TITLE
Create basic mkdocs config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/
 *.iml
 repo/
 local.properties
+
+# MkDocs build output
+site/

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,6 +11,10 @@ metadata:
       url: https://github.com/vgaidarji/dependencies-overview/blob/master/README.md
   annotations:
     github.com/project-slug: vgaidarji/dependencies-overview
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - Kotlin
+    - Gradle
 spec:
   type: library
   owner: vgaidarji

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: 'dependencies-overview-docs'
+site_description: 'Main documentation for Dependencies Overview Gradle plugin'
+repo_url: https://github.com/vgaidarji/dependencies-overview
+
+nav:
+  - README: README.md
+
+plugins:
+  - techdocs-core
+
+theme: readthedocs
+
+docs_dir: '.'


### PR DESCRIPTION
### What has been done
- Added basic [mkdocs](https://www.mkdocs.org/) configuration. 
- `techdocs-core` plugin is necessary for integration with backstage.io. https://backstage.io/docs/features/techdocs/creating-and-publishing