### PR TITLE
Use lowercase tag names for backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,8 +13,8 @@ metadata:
     github.com/project-slug: vgaidarji/dependencies-overview
     backstage.io/techdocs-ref: dir:.
   tags:
-    - Kotlin
-    - Gradle
+    - kotlin
+    - gradle
 spec:
   type: library
   owner: vgaidarji


### PR DESCRIPTION
### What has been done
- Used lowercase tag names for backstage to comply with `[a-z0-9+#] separated by [-], at most 63 characters in total` format

> Policy check failed for component:default/dependencies-overview; caused by Error: tags.0 is not valid;
expected a string that is sequences of [a-z0-9+#] separated by [-], at most 63 characters in total but found Kotlin.
To learn more about catalog file format,
visit: https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr002-default-catalog-file-format.md