### PR TITLE
Create docs dir with README.md symlink

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,4 +10,4 @@ plugins:
 
 theme: readthedocs
 
-docs_dir: '.'
+docs_dir: 'docs/'


### PR DESCRIPTION
### What has been done
- Create docs dir with README.md symlink. This is to avoid moving/copying of README.md into sub-directory (`/docs`) to satisfy mkdocs which doesn't allow for root dir usage for docs. Reasoning explained https://github.com/mkdocs/mkdocs/issues/1276