### PR TITLE
Migrate from Travis/Coveralls to Circle CI/Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
+    docker:
+      - image: cimg/base:stable
+    # Add steps to the job
+    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    steps:
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  say-hello-workflow:
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,26 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
+orbs:
+  android: circleci/android@1.0.3
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+  build-and-test:
+    executor:
+      name: android/android-machine
+
     steps:
       - checkout
+
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+          name: Build, install & run
+          command: ./build-install-run.sh
+
+      - run:
+          name: Gather & upload code coverage
+          command: ./gradlew jacocoTestReport coveralls
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  say-hello-workflow:
+  main:
     jobs:
-      - say-hello
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   android: circleci/android@1.0.3
+  codecov: codecov/codecov@3.2.3
 
 jobs:
   build-and-test:
@@ -16,7 +17,8 @@ jobs:
 
       - run:
           name: Gather & upload code coverage
-          command: ./gradlew jacocoTestReport coveralls
+          command: ./gradlew jacocoTestReport
+      - codecov/upload
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dependencies overview generator plugin
 
-[![ktlint](https://img.shields.io/badge/code%20style-%E2%9D%A4-FF4081.svg)](https://ktlint.github.io/) [![Build Status](https://travis-ci.org/vgaidarji/dependencies-overview.svg?branch=master)](https://travis-ci.org/vgaidarji/dependencies-overview) [![Coverage Status](https://coveralls.io/repos/github/vgaidarji/dependencies-overview/badge.svg?branch=master)](https://coveralls.io/github/vgaidarji/dependencies-overview?branch=master)
+[![ktlint](https://img.shields.io/badge/code%20style-%E2%9D%A4-FF4081.svg)](https://ktlint.github.io/) [![Build Status](https://travis-ci.org/vgaidarji/dependencies-overview.svg?branch=master)](https://travis-ci.org/vgaidarji/dependencies-overview) [![codecov](https://codecov.io/gh/vgaidarji/dependencies-overview/branch/master/graph/badge.svg?token=QufEOkMXri)](https://codecov.io/gh/vgaidarji/dependencies-overview)
 
 [Gradle plugin](https://docs.gradle.org/current/userguide/custom_plugins.html) which gathers project dependencies and exports them in `Markdown`/`JSON` format.
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,15 +4,11 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.2.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.0"
-        classpath 'gradleorg.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.0'
 //        classpath 'com.jfrog.maven-publishing.gradle:gradle-bintray-plugin:1.8.0'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,15 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.2.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.0"
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
+        classpath 'gradleorg.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.0'
 //        classpath 'com.jfrog.maven-publishing.gradle:gradle-bintray-plugin:1.8.0'
     }
 }

--- a/dependencies-overview/build.gradle
+++ b/dependencies-overview/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'groovy'
 apply plugin: "org.jetbrains.dokka"
 apply from: file('ktlint.gradle')
 apply from: file('jacoco.gradle')
-apply from: file('coveralls.gradle')
 apply from: file('../gradle/maven-publishing.gradle')
 
 repositories {

--- a/dependencies-overview/coveralls.gradle
+++ b/dependencies-overview/coveralls.gradle
@@ -1,5 +1,0 @@
-apply plugin: 'com.github.kt3k.coveralls'
-
-coveralls {
-    sourceDirs = files(sourceSets.main.kotlin.srcDirs).files.absolutePath
-}


### PR DESCRIPTION
### What has been done
- Migrated from [Travis](https://www.travis-ci.com/) to [Circle CI](https://circleci.com/). Travis is no longer free even for public repositories 👎 .
- Migrated from [Coveralls](https://coveralls.io/) to [Codecov](https://app.codecov.io/). https://github.com/kt3k/coveralls-gradle-plugin/ is no longer actively maintained and in general Codecov service (including UI) improved a lot over time. 