### PR TITLE
Deploy different plugin version locally

### DIFF
--- a/build-install.sh
+++ b/build-install.sh
@@ -5,4 +5,7 @@ set -e
 rm -rf repo
 ./gradlew clean
 ./gradlew :dependencies-overview:build
-./gradlew publishToMavenLocal -Dmaven.repo.local="$(pwd)"/repo
+# useLocalVersion is needed to deploy locally library version that will be further referenced
+# in integration project. This is to avoid accidental usage of remote library version
+# published to maven central and to always consume latest version and make sure all tests are passing
+./gradlew publishToMavenLocal -DuseLocalVersion=true -Dmaven.repo.local="$(pwd)"/repo

--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -15,7 +15,9 @@ ext {
     publishedGroupId = 'com.vgaidarji'
     libraryName = 'dependencies-overview'
     artifact = 'dependencies-overview'
-    libraryVersion = '1.0.0'
+    localVersionSuffix = 'local'
+    libraryVersion = "1.0.0"
+    libraryVersionString = Boolean.getBoolean("useLocalVersion") ? "$libraryVersion-$localVersionSuffix" : libraryVersion
     libraryDescription = 'Generates project dependencies overview report (JSON, Markdown, etc.) from project dependencies'
 
     siteUrl = 'https://github.com/vgaidarji/dependencies-overview'
@@ -31,13 +33,12 @@ ext {
     licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
 }
 
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
             groupId = publishedGroupId
             artifactId = artifact
-            version = libraryVersion
+            version = libraryVersionString
 
             from components.java
             artifact sourcesJar

--- a/sample-android-app/app/build.gradle
+++ b/sample-android-app/app/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
     dependencies {
         // TODO reuse plugin version to avoid manual version updates
-        classpath 'com.vgaidarji:dependencies-overview:1.0.0'
+        classpath "com.vgaidarji:dependencies-overview:1.0.0-local"
         classpath 'com.github.pedrovgs:kuronometer:0.1.1'
     }
 }


### PR DESCRIPTION
### What has been done
- Introduced `useLocalVersion` parameter. It's is needed to deploy locally library version that will be further referenced in integration project. This is to avoid accidental usage of remote library version published to maven central and to always consume latest version and make sure all tests are passing.

### How to test
Run `./build-install-run.sh` script and make sure all tests succeed.