### PR TITLE
Configure publishing to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,21 @@ They contain sequence of `Gradle` commands which help building/installing/runnin
 
 **How to release**
 
-Plugin is published to [jcenter](https://bintray.com/bintray/jcenter) and [Maven Central](https://search.maven.org/) repositories.
-[gradle-jcenter-publish.gradle](./gradle/gradle-jcenter-publish.gradle) is used to publish plugin to `jcenter` and synced to `Maven Central` from there.  
-We need to specify few mandatory properties in `local.properties` file:
+Plugin is published to and [Maven Central](https://search.maven.org/) repository ([Gradle guide](https://central.sonatype.org/publish/publish-gradle)).
+[maven-publishing.gradle](./gradle/maven-publishing.gradle) contains necessary configurations.  
+We need to specify few mandatory properties in global `~/.gradle/gradle.properties` file:
 ```properties
-bintray.user=
-bintray.apikey=
-bintray.gpg.passphrase=
-```
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=
 
-`./gradlew clean build bintrayUpload -PdryRun=false` command is used to upload signed plugin artifact to `jcenter`.
+sonatypeUsername=
+sonatypePassword=
+```
+Follow [Signatory credentials](https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials) for more details.
+`publishToMavenLocal` task can be used to perform a dry run publishing.
+
+`./gradlew clean build publishMavenJavaPublicationToMavenRepository` command is used to upload signed plugin artifact to [Maven Central](https://search.maven.org/).
 
 Developed By
 ------------

--- a/README.md
+++ b/README.md
@@ -132,13 +132,19 @@ signing.keyId=
 signing.password=
 signing.secretKeyRingFile=
 
-sonatypeUsername=
-sonatypePassword=
+SONATYPE_USERNAME=
+SONATYPE_PASSWORD=
 ```
 Follow [Signatory credentials](https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials) for more details.
+
+As per https://circleci.com/blog/publishing-java-android-libraries/, 
+following environment variables should be added to Circle CI project environment variables:
+- `ORG_GRADLE_PROJECT_SONATYPE_USERNAME`
+- `ORG_GRADLE_PROJECT_SONATYPE_PASSWORD`
+
 `publishToMavenLocal` task can be used to perform a dry run publishing.
 
-`./gradlew clean build publishMavenJavaPublicationToMavenRepository` command is used to upload signed plugin artifact to [Maven Central](https://search.maven.org/).
+`./gradlew clean build publish` command is used to upload signed plugin artifact to [Maven Central](https://search.maven.org/).
 
 Developed By
 ------------

--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -83,6 +83,8 @@ publishing {
 }
 
 signing {
+    // do no require signing on Circle CI
+    required { System.getenv("CIRCLECI") == "false" }
     sign publishing.publications.mavenJava
 }
 

--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -75,8 +75,8 @@ publishing {
         maven {
             url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
             credentials {
-                username sonatypeUsername
-                password sonatypePassword
+                username findProperty('SONATYPE_USERNAME')
+                password findProperty('SONATYPE_PASSWORD')
             }
         }
     }

--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -17,7 +17,8 @@ ext {
     libraryName = 'dependencies-overview'
     artifact = 'dependencies-overview'
     localVersionSuffix = 'local'
-    libraryVersion = "1.0.0"
+    // :bulb: keep sample-android-app/app/build.gradle in sync
+    libraryVersion = "1.0.1"
     libraryVersionString = Boolean.getBoolean("useLocalVersion") ? "$libraryVersion-$localVersionSuffix" : libraryVersion
     libraryDescription = 'Generates project dependencies overview report (JSON, Markdown, etc.) from project dependencies'
 

--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'java'
+apply plugin: 'signing'
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveClassifier.set('javadoc')
@@ -69,6 +70,19 @@ publishing {
             }
         }
     }
+    repositories {
+        maven {
+            url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+            credentials {
+                username sonatypeUsername
+                password sonatypePassword
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.mavenJava
 }
 
 javadoc {

--- a/sample-android-app/app/build.gradle
+++ b/sample-android-app/app/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
     dependencies {
         // TODO reuse plugin version to avoid manual version updates
-        classpath "com.vgaidarji:dependencies-overview:1.0.0-local"
+        classpath "com.vgaidarji:dependencies-overview:1.0.1-local"
         classpath 'com.github.pedrovgs:kuronometer:0.1.1'
     }
 }


### PR DESCRIPTION
### What has been done
- Removed old Jcenter publishing code.
- Configured publish to Maven Central.

### How to test
Run `publishToMavenLocal` and confirm that artifacts have been signed and published correctly to `~/.m2/repository`. 
Once new version is ready to be released, run `publish` to upload to Maven Central and verify new version is discoverable on project page https://central.sonatype.dev/artifact/com.vgaidarji/dependencies-overview