### PR TITLE
Use legacy sonatype URL

### DIFF
--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -73,7 +73,7 @@ publishing {
     }
     repositories {
         maven {
-            url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+            url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
             credentials {
                 username findProperty('SONATYPE_USERNAME')
                 password findProperty('SONATYPE_PASSWORD')


### PR DESCRIPTION
### What has been done
- Used legacy sonatype URL as my sonatype account has been created before February 2021.

As per https://central.sonatype.org/publish/publish-guide/#deployment: 
> Note: As of February 2021, all new projects began being provisioned on https://s01.oss.sonatype.org/.
If your project is not provisioned on https://s01.oss.sonatype.org/, you will want to login to the legacy host https://oss.sonatype.org/.