### PR TITLE
Use Nexus Publishing plugin for automatic publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ following environment variables should be added to Circle CI project environment
 - `ORG_GRADLE_PROJECT_SONATYPE_USERNAME`
 - `ORG_GRADLE_PROJECT_SONATYPE_PASSWORD`
 
-`publishToMavenLocal` task can be used to perform a dry run publishing.
+`publishToMavenLocal` task can be used to perform a dry run publishing to local maven repository.
 
-`./gradlew clean build publish` command is used to upload signed plugin artifact to [Maven Central](https://search.maven.org/).
+For automatic publishing from Sonatype Nexus staging repository to release https://github.com/gradle-nexus/publish-plugin/ plugin is used.
+`./gradlew clean build publishToSonatype closeSonatypeStagingRepository` command is used to upload signed plugin artifact to [Maven Central](https://search.maven.org/).
+Publishing may take some time, check https://oss.sonatype.org for new published version.
 
 Developed By
 ------------

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,20 @@
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
+
 buildscript {
     ext.kotlin_version = '1.6.20'
 
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.2.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.0"
-//        classpath 'com.jfrog.maven-publishing.gradle:gradle-bintray-plugin:1.8.0'
+        classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
     }
 }
 

--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'java'
 apply plugin: 'signing'
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveClassifier.set('javadoc')
@@ -74,6 +73,7 @@ publishing {
     }
 }
 
+// io.github.gradle-nexus.publish-plugin
 nexusPublishing {
     repositories {
         sonatype {

--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'java'
 apply plugin: 'signing'
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveClassifier.set('javadoc')
@@ -71,13 +72,15 @@ publishing {
             }
         }
     }
+}
+
+nexusPublishing {
     repositories {
-        maven {
-            url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            credentials {
-                username findProperty('SONATYPE_USERNAME')
-                password findProperty('SONATYPE_PASSWORD')
-            }
+        sonatype {
+            // my acc is registered on https://oss.sonatype.org
+            // and for legacy accs repo url is not required by plugin
+            username = findProperty('SONATYPE_USERNAME')
+            password = findProperty('SONATYPE_PASSWORD')
         }
     }
 }


### PR DESCRIPTION
### What has been done
- Used [Nexus Publishing](https://github.com/gradle-nexus/publish-plugin/) plugin for automatic publishing of new versions from staging to release Sonatype Nexus repository.

When artifacts are being released they first land on staging repo https://oss.sonatype.org/\#stagingRepositories from where manual intervention is required to further push the new project version to release Sonatype repository. Nexus Publishing plugin allows for automatic propagation of new project version from staging repo to release.
More details on https://central.sonatype.org/publish/release/