### PR TITLE
Fix publish-plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Apply the plugin in your `build.gradle`:
 ```groovy
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.vgaidarji:dependencies-overview:1.0.0'
+        classpath 'com.vgaidarji:dependencies-overview:<VERSION>'
     }
 }
 
@@ -145,8 +145,8 @@ following environment variables should be added to Circle CI project environment
 `publishToMavenLocal` task can be used to perform a dry run publishing to local maven repository.
 
 For automatic publishing from Sonatype Nexus staging repository to release https://github.com/gradle-nexus/publish-plugin/ plugin is used.
-`./gradlew clean build publishToSonatype closeSonatypeStagingRepository` command is used to upload signed plugin artifact to [Maven Central](https://search.maven.org/).
-Publishing may take some time, check https://oss.sonatype.org for new published version.
+`./gradlew clean build publishToSonatype closeAndReleaseSonatypeStagingRepository` command is used to upload signed plugin artifact to [Maven Central](https://search.maven.org/).
+Publishing may take some time, check https://oss.sonatype.org for newly published version.
 
 Developed By
 ------------

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
+apply from: file('gradle/nexus-publishing.gradle')
 
 buildscript {
     ext.kotlin_version = '1.6.20'

--- a/gradle/maven-publishing.gradle
+++ b/gradle/maven-publishing.gradle
@@ -13,12 +13,11 @@ task sourcesJar(type: Jar) {
 }
 
 ext {
-    publishedGroupId = 'com.vgaidarji'
+    // some fields in nexus-publishing.gradle as required by publish-plugin
     libraryName = 'dependencies-overview'
     artifact = 'dependencies-overview'
     localVersionSuffix = 'local'
     // :bulb: keep sample-android-app/app/build.gradle in sync
-    libraryVersion = "1.0.1"
     libraryVersionString = Boolean.getBoolean("useLocalVersion") ? "$libraryVersion-$localVersionSuffix" : libraryVersion
     libraryDescription = 'Generates project dependencies overview report (JSON, Markdown, etc.) from project dependencies'
 
@@ -69,18 +68,6 @@ publishing {
                     url = gitUrl
                 }
             }
-        }
-    }
-}
-
-// io.github.gradle-nexus.publish-plugin
-nexusPublishing {
-    repositories {
-        sonatype {
-            // my acc is registered on https://oss.sonatype.org
-            // and for legacy accs repo url is not required by plugin
-            username = findProperty('SONATYPE_USERNAME')
-            password = findProperty('SONATYPE_PASSWORD')
         }
     }
 }

--- a/gradle/nexus-publishing.gradle
+++ b/gradle/nexus-publishing.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
+
+ext {
+    publishedGroupId = 'com.vgaidarji'
+    libraryVersion = '1.0.1'
+}
+
+group = publishedGroupId
+version = libraryVersion
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            // my acc is registered on https://oss.sonatype.org
+            // and for legacy accs repo url is not required by plugin
+            username = findProperty('SONATYPE_USERNAME')
+            password = findProperty('SONATYPE_PASSWORD')
+        }
+    }
+}


### PR DESCRIPTION
### What has been done
- Fixed `publish-plugin` configuration. `group`/`version` had to be added to root `build.gradle` and this required some refactoring so that maven publishing configuration correctly references those fields from another build file.
- Replaced `jcenter()` documentation leftover with `mavenCentral()`

### How to test
- Make sure `./build-install-run.sh` succeeds as well as build on CI
- Install locally the plugin via `publishToMavenLocal` and confirm installed artifact uses correct version
- Once release tag created, release new version to Sonatype Nexus via `./gradlew clean build publishToSonatype closeAndReleaseSonatypeStagingRepository` and confirm that new version is released to https://central.sonatype.dev/artifact/com.vgaidarji/dependencies-overview/ and staging nexus repository is automatically closed (https://oss.sonatype.org/#stagingRepositories).

